### PR TITLE
Fix layout/scrolling, add SEO and Google Analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Google Analytics 4 measurement ID (e.g. G-XXXXXXXXXX).
+# Leave empty to disable analytics locally; set it in production to enable
+# page-view and click-event tracking.
+NEXT_PUBLIC_GA_MEASUREMENT_ID=

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/components/About/About.tsx
+++ b/components/About/About.tsx
@@ -1,36 +1,47 @@
-import { Flex, Text, Image, MediaQuery } from '@mantine/core';
+import { Flex, Text, Image, MediaQuery, Title } from '@mantine/core';
 
 export function About() {
   return (
-    <Flex h="100vh">
-      <MediaQuery smallerThan="md" styles={{ width: '0%' }}>
+    <Flex mih="100vh">
+      <MediaQuery smallerThan="md" styles={{ width: '0%', display: 'none' }}>
         <Flex w="35%">
-          <Image src="/assets/about.webp" alt="Olive drops" height="100vh" />
+          <Image
+            src="/assets/about.webp"
+            alt="Fresh olives and greens at Boket78 restaurant"
+            height="100vh"
+            fit="cover"
+          />
         </Flex>
       </MediaQuery>
       <MediaQuery
         smallerThan="md"
         styles={{
-          background: `url('assets/about_darken.webp')`,
+          background: `url('/assets/about_darken.webp')`,
           width: '100%',
-          height: '100%',
-          backgroundSize: "cover",
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
         }}
       >
         <Flex
           sx={{
             background: '#02323C',
           }}
-          h="100vh"
+          mih="100vh"
           w="65%"
           direction="column"
           justify="center"
+          py={80}
         >
-          <Text mx={40} size="calc(14px + 0.390625vw)">
+          <Title order={2} color="white" mx={40} mb="md" sx={{ fontSize: 'calc(14px + 0.390625vw)' }}>
             About
-          </Text>
+          </Title>
           <Text size="calc(20px + 0.1vw)" mx={40}>
-          Welcome to Boket78, a hidden gem in Bol, on the picturesque island of Brač. Nestled in the heart of the town, our restaurant offers a beautiful location combined with the privacy of our secret garden. We take pride in presenting traditional Dalmatian cuisine with a modern twist, using only the freshest ingredients. Join us for an unforgettable dining experience that combines the best of local flavors and a serene ambiance. Welcome to Boket78, where culinary excellence meets island charm.
+            Welcome to Boket78, a hidden gem in Bol, on the picturesque island of Brač. Nestled in
+            the heart of the town, our restaurant offers a beautiful location combined with the
+            privacy of our secret garden. We take pride in presenting traditional Dalmatian cuisine
+            with a modern twist, using only the freshest ingredients. Join us for an unforgettable
+            dining experience that combines the best of local flavors and a serene ambiance. Welcome
+            to Boket78, where culinary excellence meets island charm.
           </Text>
         </Flex>
       </MediaQuery>

--- a/components/Contact/Contact.tsx
+++ b/components/Contact/Contact.tsx
@@ -1,4 +1,4 @@
-import { BackgroundImage, Flex, Container, Text, Anchor, Image } from '@mantine/core';
+import { BackgroundImage, Flex, Container, Text, Image, Title } from '@mantine/core';
 import {
   IconBrandTripadvisor,
   IconBrandFacebook,
@@ -6,6 +6,7 @@ import {
   IconPhone,
   IconMail,
 } from '@tabler/icons-react';
+import { trackClick } from '../../lib/gtag';
 
 export function Contact() {
   const socials = [
@@ -25,7 +26,7 @@ export function Contact() {
       icon: <IconBrandTripadvisor color="white" size={24} />,
     },
     {
-      name: 'Call is to book a table',
+      name: 'Call us to book a table',
       link: 'tel:+385995935023',
       icon: <IconPhone color="white" size={24} />,
     },
@@ -37,34 +38,40 @@ export function Contact() {
   ];
 
   return (
-    <BackgroundImage src="/assets/contact.webp" h="100vh">
-      <Flex w="100vw" direction="column" align="center" justify="center" h="100vh">
-        <Image src="/assets/illustration.webp" maw={500} />
+    <BackgroundImage src="/assets/contact.webp" mih="100vh">
+      <Flex w="100%" direction="column" align="center" justify="center" mih="100vh" py={60}>
+        <Image src="/assets/illustration.webp" alt="Boket78 illustration" maw={500} />
         <Container fluid>
-          <Text size="calc(28px + 0.390625vw)" ml={10}>
+          <Title order={2} color="white" ml={10} sx={{ fontSize: 'calc(28px + 0.390625vw)' }}>
             Get in touch with us
-          </Text>
-          <Flex justify="space-around" m={30}>
-            {socials.map((social) => {
-              return (
-                <a href={social.link} target="_blank">
-                  <Flex
-                    align="center"
-                    style={{
-                      border: '1px solid white',
-                      padding: '5px',
-                      borderRadius: '15%',
-                    }}
-                  >
-                    {social.icon}
-                  </Flex>
-                </a>
-              );
-            })}
+          </Title>
+          <Flex justify="space-around" wrap="wrap" gap="md" m={30}>
+            {socials.map((social) => (
+              <a
+                key={social.name}
+                href={social.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={social.name}
+                title={social.name}
+                onClick={() => trackClick(`contact:${social.name}`, 'contact')}
+              >
+                <Flex
+                  align="center"
+                  style={{
+                    border: '1px solid white',
+                    padding: '5px',
+                    borderRadius: '15%',
+                  }}
+                >
+                  {social.icon}
+                </Flex>
+              </a>
+            ))}
           </Flex>
         </Container>
-        <Text>Ul. Radića Frane 14</Text>
-        <Text>Open 12AM - 12PM</Text>
+        <Text>Ul. Radića Frane 14, 21420 Bol, Brač</Text>
+        <Text>Open 12PM – 12AM</Text>
       </Flex>
     </BackgroundImage>
   );

--- a/components/Design/Design.tsx
+++ b/components/Design/Design.tsx
@@ -7,57 +7,21 @@ interface CardProps {
 }
 
 function Card({ image, title }: CardProps) {
-  return (
-    <Image 
-        src={image}
-        alt={title}
-        height="100vh"
-    />
-  );
+  return <Image src={image} alt={title} height="80vh" fit="cover" />;
 }
 
 const data = [
-  {
-    image:
-      '/assets/interior1.webp',
-    title: 'Best forests to visit in North America',
-    category: 'nature',
-  },
-  {
-    image:
-      '/assets/interior3.webp',
-    title: 'Best forests to visit in North America',
-    category: 'nature',
-  },
-  {
-    image:
-      '/assets/interior4.webp',
-    title: 'Best forests to visit in North America',
-    category: 'nature',
-  },
-  {
-    image:
-      '/assets/interior5.webp',
-    title: 'Best forests to visit in North America',
-    category: 'nature',
-  },
-  {
-    image:
-      '/assets/interior6.webp',
-    title: 'Best forests to visit in North America',
-    category: 'nature',
-  },
-  {
-    image:
-      '/assets/interior7.webp',
-    title: 'Best forests to visit in North America',
-    category: 'nature',
-  },
+  { image: '/assets/interior1.webp', title: 'Interior of Boket78 restaurant in Bol, Brač' },
+  { image: '/assets/interior3.webp', title: 'Secret garden seating at Boket78 restaurant' },
+  { image: '/assets/interior4.webp', title: 'Cozy dining space at Boket78 in Bol' },
+  { image: '/assets/interior5.webp', title: 'Ambient interior design at Boket78 restaurant' },
+  { image: '/assets/interior6.webp', title: 'Restaurant atmosphere at Boket78, Brač island' },
+  { image: '/assets/interior7.webp', title: 'Boket78 restaurant decor and seating in Bol' },
 ];
 
 export function DesignCardsCarousel() {
   const slides = data.map((item) => (
-    <Carousel.Slide key={item.title}>
+    <Carousel.Slide key={item.image}>
       <Card {...item} />
     </Carousel.Slide>
   ));
@@ -68,6 +32,8 @@ export function DesignCardsCarousel() {
       slideGap="xl"
       align="start"
       slidesToScroll={1}
+      loop
+      withIndicators
     >
       {slides}
     </Carousel>

--- a/components/Gallery/Gallery.tsx
+++ b/components/Gallery/Gallery.tsx
@@ -1,7 +1,5 @@
 import { Carousel } from '@mantine/carousel';
-import { useMediaQuery } from '@mantine/hooks';
-import { useMantineTheme, rem, Image } from '@mantine/core';
-
+import { rem, Image } from '@mantine/core';
 
 interface CardProps {
   image: string;
@@ -9,63 +7,22 @@ interface CardProps {
 }
 
 function Card({ image, title }: CardProps) {
-  return (
-    <Image 
-        src={image}
-        alt={title}
-        height="100vh"
-    />
-  );
+  return <Image src={image} alt={title} height="80vh" fit="cover" />;
 }
 
 const data = [
-  {
-    image:
-      '/assets/food1.webp',
-    title: 'Best forests to visit in North America',
-    category: 'nature',
-  },
-  {
-    image:
-      '/assets/food2.webp',
-    title: 'Best forests to visit in North America',
-    category: 'nature',
-  },
-  {
-    image:
-      '/assets/food3.webp',
-    title: 'Best forests to visit in North America',
-    category: 'nature',
-  },
-  {
-    image:
-      '/assets/food4.webp',
-    title: 'Best forests to visit in North America',
-    category: 'nature',
-  },
-  {
-    image:
-      '/assets/food5.webp',
-    title: 'Best forests to visit in North America',
-    category: 'nature',
-  },
-  {
-    image:
-      '/assets/food6.webp',
-    title: 'Best forests to visit in North America',
-    category: 'nature',
-  },
-  {
-    image:
-      '/assets/food7.webp',
-    title: 'Best forests to visit in North America',
-    category: 'nature',
-  },
+  { image: '/assets/food1.webp', title: 'Dalmatian dish served at Boket78 restaurant in Bol' },
+  { image: '/assets/food2.webp', title: 'Fresh Adriatic seafood plate at Boket78' },
+  { image: '/assets/food3.webp', title: 'Traditional Dalmatian cuisine with a modern twist at Boket78' },
+  { image: '/assets/food4.webp', title: 'Locally sourced dish from Boket78 in Bol, Brač' },
+  { image: '/assets/food5.webp', title: 'Seasonal specialty served at Boket78 restaurant' },
+  { image: '/assets/food6.webp', title: 'Chef-prepared dish at Boket78, Bol' },
+  { image: '/assets/food7.webp', title: 'Dessert at Boket78 restaurant in Bol, Brač' },
 ];
 
 export function CardsCarousel() {
   const slides = data.map((item) => (
-    <Carousel.Slide key={item.title}>
+    <Carousel.Slide key={item.image}>
       <Card {...item} />
     </Carousel.Slide>
   ));
@@ -76,6 +33,8 @@ export function CardsCarousel() {
       slideGap="xl"
       align="start"
       slidesToScroll={1}
+      loop
+      withIndicators
     >
       {slides}
     </Carousel>

--- a/components/Info/Info.jsx
+++ b/components/Info/Info.jsx
@@ -1,15 +1,33 @@
-import { Flex, Text } from '@mantine/core';
+import { Flex, Text, Title } from '@mantine/core';
 
 export function Info() {
-    return (
-        <Flex
-            bg="red"
-        >
-            <Text>MORE BEER d.o.o.</Text>
-            <Text>Ulica Frane Radića 14, 21420 Bol</Text>
-            <Text>OIB: 66779892111</Text>
-            <Text>Direktor: Danijel Čamber </Text>
-            <Text>IBAN: HR5024070001100207879</Text>
-        </Flex>
-    )
+  const details = [
+    { label: 'Company', value: 'MORE BEER d.o.o.' },
+    { label: 'Address', value: 'Ulica Frane Radića 14, 21420 Bol' },
+    { label: 'OIB', value: '66779892111' },
+    { label: 'Director', value: 'Danijel Čamber' },
+    { label: 'IBAN', value: 'HR5024070001100207879' },
+  ];
+
+  return (
+    <Flex
+      bg="#02323C"
+      mih="100vh"
+      direction="column"
+      align="center"
+      justify="center"
+      gap="sm"
+      py={80}
+      px={20}
+    >
+      <Title order={1} color="white" mb="lg" align="center">
+        Company Information
+      </Title>
+      {details.map((detail) => (
+        <Text key={detail.label} align="center">
+          <strong>{detail.label}:</strong> {detail.value}
+        </Text>
+      ))}
+    </Flex>
+  );
 }

--- a/components/Legal/Legal.tsx
+++ b/components/Legal/Legal.tsx
@@ -1,19 +1,19 @@
-// @ts-nocheck
 import { Flex, Image } from '@mantine/core';
 
 export function Legal() {
   return (
-    <Flex h="200px" wrap="wrap" align="center" justify="space-around">
-      <Image src="/assets/hamag1.jpg" width="400px" />
-      <Image src="/assets/eu1.jpg" width="400px" />
-      <div
-        id="r-rcm"
-        dataLength="33"
-        className=" r-rcm_black "
-        onClick="if(event.target.nodeName.toLowerCase() != 'a') {window.open(this.querySelector('.rest-white_center').href);return 0;}"
-      >
+    <Flex mih="200px" wrap="wrap" align="center" justify="space-around" bg="#02323C" py={20} gap="md">
+      <Image src="/assets/hamag1.jpg" alt="HAMAG-BICRO co-financing logo" width={400} fit="contain" />
+      <Image src="/assets/eu1.jpg" alt="European Union co-financing logo" width={400} fit="contain" />
+      {/* Restaurant Guru award widget (styles/behaviour provided by r_rcm.css). */}
+      <div id="r-rcm" data-length="33" className=" r-rcm_black ">
         {' '}
-        <a href="https://restaurantguru.com/Beer-and-More-Bol" className="r-rcm_r-link" target="blank">
+        <a
+          href="https://restaurantguru.com/Beer-and-More-Bol"
+          className="r-rcm_r-link"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           Boket78
         </a>{' '}
         <div className="r-rcm_year">2023</div>{' '}
@@ -33,7 +33,7 @@ export function Legal() {
             {' '}
             <defs>
               {' '}
-              <path id="r-rcm-arc" d="M 12 72 a 60 60 0 0 0 120 0"></path>{' '}
+              <path id="r-rcm-arc" d="M 12 72 a 60 60 0 0 0 120 0" />{' '}
             </defs>{' '}
             <text className="r-rcm_headingbottom r-rcm_small " fill="#fff" textAnchor="middle">
               {' '}

--- a/components/Menu/Menu.tsx
+++ b/components/Menu/Menu.tsx
@@ -1,49 +1,81 @@
-import { Flex, BackgroundImage, Button, Text } from '@mantine/core';
+import { Flex, BackgroundImage, Button, Text, Title } from '@mantine/core';
+import { trackClick } from '../../lib/gtag';
+
+interface MenuLink {
+  label: string;
+  href: string;
+}
+
+const menuLinks: MenuLink[] = [
+  {
+    label: 'View our menu in English',
+    href: 'https://drive.google.com/file/d/1H7Ne1TQcR9XSS6k-Dh5sKfpnVeSKubg0/view?usp=sharing',
+  },
+  {
+    label: 'View our menu in Croatian',
+    href: 'https://drive.google.com/file/d/1sAIYnG89wLxyE3zTtvCYVND4OEB45LfV/view?usp=sharing',
+  },
+  {
+    label: 'View our dessert menu in English',
+    href: 'https://drive.google.com/file/d/1T4ycn-trg5H6nyLurJESZsCYpCz6VHrB/view?usp=sharing',
+  },
+  {
+    label: 'View our dessert menu in Croatian',
+    href: 'https://drive.google.com/file/d/1EWdfEqT4MXBQQzeHZd8-LQsM9sR5rkbW/view?usp=sharing',
+  },
+];
+
+const drinkLinks: MenuLink[] = [
+  {
+    label: 'View our wine card',
+    href: 'https://drive.google.com/file/d/1JZW_PtDR-bNDkT6T1FRPKN1oqYwXpL2o/view?usp=sharing',
+  },
+  {
+    label: 'View our drinks menu',
+    href: 'https://drive.google.com/file/d/1vwcyXGnleIBl8NaJ3VAIcqe7pAzaee5m/view?usp=sharing',
+  },
+];
+
+function MenuButton({ label, href }: MenuLink) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={() => trackClick(`menu:${label}`, 'menu')}
+    >
+      <Button p={5} m={5}>
+        {label}
+      </Button>
+    </a>
+  );
+}
 
 export function Menu() {
   return (
-    <BackgroundImage src="/assets/menu_darken.webp" h="100vh">
-      <Flex align="center" justify="center" direction="column" h="100vh">
-        {/* @ts-ignore */}
-        <Text align="center!important" maw={500} size="calc(16px + 0.390625vw)" p={5} m={5}>
-          Discover a modern twist on traditional Dalmatian cuisine at our restaurant. Our menu features fresh ingredients, including herbs from our garden. Delight in Adriatic Sea seafood or savor locally sourced sheep meat from Brač. Join us for a culinary adventure celebrating Dalmatia's essence in every bite.
+    <BackgroundImage src="/assets/menu_darken.webp" mih="100vh">
+      <Flex align="center" justify="center" direction="column" mih="100vh" py={80}>
+        <Title order={2} color="white" align="center" mb="md" sx={{ fontSize: 'calc(20px + 0.5vw)' }}>
+          Our Menu
+        </Title>
+        <Text align="center" maw={500} size="calc(16px + 0.390625vw)" p={5} m={5}>
+          Discover a modern twist on traditional Dalmatian cuisine at our restaurant. Our menu
+          features fresh ingredients, including herbs from our garden. Delight in Adriatic Sea
+          seafood or savor locally sourced sheep meat from Brač. Join us for a culinary adventure
+          celebrating Dalmatia&apos;s essence in every bite.
         </Text>
-        <a href="https://drive.google.com/file/d/1H7Ne1TQcR9XSS6k-Dh5sKfpnVeSKubg0/view?usp=sharing" target="_blank">
-          <Button p={5} m={5}>
-            View our menu in English
-          </Button>
-        </a>
-        <a href="https://drive.google.com/file/d/1sAIYnG89wLxyE3zTtvCYVND4OEB45LfV/view?usp=sharing" target="_blank">
-          <Button p={5} m={5}>
-            View our menu in Croatian
-          </Button>
-        </a>
-
-        <a href="https://drive.google.com/file/d/1T4ycn-trg5H6nyLurJESZsCYpCz6VHrB/view?usp=sharing" target="_blank">
-          <Button p={5} m={5}>
-            View our dessert menu in English
-          </Button>
-        </a>
-        <a href="https://drive.google.com/file/d/1EWdfEqT4MXBQQzeHZd8-LQsM9sR5rkbW/view?usp=sharing" target="_blank">
-          <Button p={5} m={5}>
-            View our dessert menu in Croatian
-          </Button>
-        </a>
-        {/* @ts-ignore */}
-        <Text align="center!important" maw={500} size="calc(16px + 0.390625vw)" p={5} m={5}>
-          Explore the finest Croatian wines on our curated list. Discover flavors from Istria, Slavonia, Central Croatia, and Dalmatia. Indulge in aromatic whites, elegant reds, and refreshing rosés. Our knowledgeable staff will help you choose the perfect wine to enhance your dining experience. Cheers to Croatia's remarkable winemaking!
+        {menuLinks.map((link) => (
+          <MenuButton key={link.label} {...link} />
+        ))}
+        <Text align="center" maw={500} size="calc(16px + 0.390625vw)" p={5} m={5}>
+          Explore the finest Croatian wines on our curated list. Discover flavors from Istria,
+          Slavonia, Central Croatia, and Dalmatia. Indulge in aromatic whites, elegant reds, and
+          refreshing rosés. Our knowledgeable staff will help you choose the perfect wine to enhance
+          your dining experience. Cheers to Croatia&apos;s remarkable winemaking!
         </Text>
-        <a href="https://drive.google.com/file/d/1JZW_PtDR-bNDkT6T1FRPKN1oqYwXpL2o/view?usp=sharing" target="_blank">
-          <Button p={5} m={5}>
-            View our wine card
-          </Button>
-        </a>
-        <a href="https://drive.google.com/file/d/1vwcyXGnleIBl8NaJ3VAIcqe7pAzaee5m/view?usp=sharing" target="_blank">
-          <Button p={5} m={5}>
-            View our drinks menu
-          </Button>
-        </a>
-
+        {drinkLinks.map((link) => (
+          <MenuButton key={link.label} {...link} />
+        ))}
       </Flex>
     </BackgroundImage>
   );

--- a/components/Navigation/Navigation.tsx
+++ b/components/Navigation/Navigation.tsx
@@ -1,128 +1,101 @@
-import { Flex, MediaQuery, Transition, Anchor } from '@mantine/core';
-import { useState } from 'react';
+import { CSSProperties, useState } from 'react';
 import Link from 'next/link';
+import { Squash as Hamburger } from 'hamburger-react';
+import { trackClick } from '../../lib/gtag';
+
+interface NavItem {
+  label: string;
+  href: string;
+  external?: boolean;
+}
+
+const navItems: NavItem[] = [
+  { label: 'Home', href: '#landing' },
+  { label: 'About us', href: '#about' },
+  { label: 'Menu', href: '#menu' },
+  { label: 'Gallery', href: '#gallery' },
+  { label: 'Contact us', href: '#contact' },
+  { label: 'Information', href: '/info', external: true },
+];
+
+// Plain inline styles keep the overlay reliable: it mounts only on the client
+// (Mantine's emotion styles are extracted at SSR time and would not be present
+// for a client-only-mounted component), so we avoid Mantine style props here.
+const linkStyle: CSSProperties = {
+  color: 'white',
+  textDecoration: 'none',
+  fontSize: 'clamp(28px, 5vw, 48px)',
+  fontWeight: 400,
+  padding: '8px 0',
+  marginTop: 20,
+};
 
 export function Navigation() {
   const [toggled, setToggled] = useState(false);
 
+  const handleNavClick = (label: string) => {
+    trackClick(`nav:${label}`, 'navigation');
+    setToggled(false);
+  };
+
   return (
     <>
-      <Transition mounted={toggled} transition="slide-right" duration={400} timingFunction="ease">
-        {(styles) => (
-          <MediaQuery
-            smallerThan="xs"
-            styles={{
-              flexDirection: 'column',
-              height: '100vh',
-            }}
-          >
-            <Flex
-              h="100%"
-              w="100%"
-              bg="#02323C"
-              direction="row"
-              pos="fixed"
-              top={0}
-              style={{ ...styles, zIndex: 90 }}
-            >
-              <Flex direction="column" w="70%" mt={90}>
-                <MediaQuery
-                  smallerThan="xs"
-                  styles={{
-                    marginLeft: 50,
-                  }}
-                >
-                  <Anchor
-                    ml={100}
-                    mt={50}
-                    p={5}
-                    size={68}
-                    weight={400}
-                    href="#landing"
-                    onClick={() => setToggled(false)}
-                  >
-                    Home
-                  </Anchor>
-                </MediaQuery>
-                <MediaQuery
-                  smallerThan="xs"
-                  styles={{
-                    marginLeft: 50,
-                  }}
-                >
-                  <Anchor
-                    ml={100}
-                    mt={50}
-                    p={5}
-                    size={58}
-                    weight={400}
-                    href="#about"
-                    onClick={() => setToggled(false)}
-                  >
-                    About us
-                  </Anchor>
-                </MediaQuery>
-                <MediaQuery
-                  smallerThan="xs"
-                  styles={{
-                    marginLeft: 50,
-                  }}
-                >
-                  <Anchor
-                    ml={100}
-                    mt={50}
-                    p={5}
-                    size={58}
-                    weight={400}
-                    href="#menu"
-                    onClick={() => setToggled(false)}
-                  >
-                    Menu
-                  </Anchor>
-                </MediaQuery>
-                <MediaQuery
-                  smallerThan="xs"
-                  styles={{
-                    marginLeft: 50,
-                  }}
-                >
-                  <Anchor
-                    ml={100}
-                    mt={50}
-                    p={5}
-                    size={68}
-                    weight={400}
-                    href="#contact"
-                    onClick={() => setToggled(false)}
-                  >
-                    Contact us
-                  </Anchor>
-                </MediaQuery>
-                <MediaQuery
-                  smallerThan="xs"
-                  styles={{
-                    marginLeft: 50,
-                  }}
-                >
-                  <Link href="/info">
-                    <Anchor
-                      ml={100}
-                      mt={50}
-                      p={5}
-                      size={68}
-                      weight={400}
-                      href="#contact"
-                      onClick={() => setToggled(false)}
-                    >
-                      Information
-                    </Anchor>
-                  </Link>
-                </MediaQuery>
-              </Flex>
-            </Flex>
-          </MediaQuery>
-        )}
-      </Transition>
+      {/* Hamburger toggle — fixed on top of everything so the menu is always reachable. */}
+      <div style={{ position: 'fixed', top: 10, left: 10, zIndex: 100 }}>
+        <Hamburger
+          toggled={toggled}
+          toggle={setToggled}
+          color="#ffffff"
+          label="Toggle navigation menu"
+          size={28}
+        />
+      </div>
+
+      <nav
+        aria-hidden={!toggled}
+        style={{
+          position: 'fixed',
+          inset: 0,
+          zIndex: 90,
+          backgroundColor: '#02323C',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          transform: toggled ? 'translateX(0)' : 'translateX(-100%)',
+          transition: 'transform 400ms ease',
+          visibility: toggled ? 'visible' : 'hidden',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            paddingLeft: 'clamp(40px, 8vw, 100px)',
+          }}
+        >
+          {navItems.map((item) =>
+            item.external ? (
+              <Link
+                key={item.label}
+                href={item.href}
+                style={linkStyle}
+                onClick={() => handleNavClick(item.label)}
+              >
+                {item.label}
+              </Link>
+            ) : (
+              <a
+                key={item.label}
+                href={item.href}
+                style={linkStyle}
+                onClick={() => handleNavClick(item.label)}
+              >
+                {item.label}
+              </a>
+            )
+          )}
+        </div>
+      </nav>
     </>
   );
 }

--- a/components/Welcome/Welcome.tsx
+++ b/components/Welcome/Welcome.tsx
@@ -8,14 +8,17 @@ import logo from '../../public/assets/sized.webp';
 export function Welcome() {
   return (
     <BackgroundImage src="/assets/landing.webp" h="100vh">
-      <Flex align="center" justify="center" h="100vh" direction="column" gap="md">
+      <Flex align="center" justify="center" h="100vh" direction="column" gap="md" px="md">
         <Image src={logo} alt="Boket78 restaurant logo" width={300} priority />
         <Title
           order={1}
           color="white"
           weight={300}
-          align="center"
-          sx={{ fontSize: 'calc(46px + 0.390625vw)' }}
+          sx={{
+            fontSize: 'clamp(32px, 6vw, 60px)',
+            textAlign: 'center',
+            maxWidth: '90vw',
+          }}
         >
           Food for your island mood
         </Title>

--- a/components/Welcome/Welcome.tsx
+++ b/components/Welcome/Welcome.tsx
@@ -1,4 +1,4 @@
-import { Flex, BackgroundImage, Text } from '@mantine/core';
+import { Flex, BackgroundImage, Title } from '@mantine/core';
 
 import React from 'react';
 import Image from 'next/image';
@@ -8,14 +8,17 @@ import logo from '../../public/assets/sized.webp';
 export function Welcome() {
   return (
     <BackgroundImage src="/assets/landing.webp" h="100vh">
-      <Flex align="center" h="100vh" direction="column">
-        <Image src={logo} alt="Boket 78 logo" width={300} style={{ marginTop: -110 }} />
-        <Flex h="100vh" align="center">
-          {/* @ts-ignore */}
-          <Text size="calc(46px + 0.390625vw)" mt="-220px" weight={300} align="center!important">
-            Food for your island mood
-          </Text>
-        </Flex>
+      <Flex align="center" justify="center" h="100vh" direction="column" gap="md">
+        <Image src={logo} alt="Boket78 restaurant logo" width={300} priority />
+        <Title
+          order={1}
+          color="white"
+          weight={300}
+          align="center"
+          sx={{ fontSize: 'calc(46px + 0.390625vw)' }}
+        >
+          Food for your island mood
+        </Title>
       </Flex>
     </BackgroundImage>
   );

--- a/lib/gtag.ts
+++ b/lib/gtag.ts
@@ -1,0 +1,42 @@
+// Google Analytics 4 helper.
+// Set NEXT_PUBLIC_GA_MEASUREMENT_ID (e.g. "G-XXXXXXXXXX") in your environment
+// to enable analytics. When it is empty, all calls below are no-ops so the
+// site works fine in development or before an ID is provisioned.
+export const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ?? '';
+
+export const isAnalyticsEnabled = () =>
+  typeof window !== 'undefined' && GA_MEASUREMENT_ID.length > 0 && typeof window.gtag === 'function';
+
+// Track a page view (used on client-side route changes).
+export const pageview = (url: string) => {
+  if (!isAnalyticsEnabled()) return;
+  window.gtag('config', GA_MEASUREMENT_ID, { page_path: url });
+};
+
+export interface GAEvent {
+  action: string;
+  category: string;
+  label?: string;
+  value?: number;
+}
+
+// Track a custom event, e.g. a menu button or social link click.
+export const event = ({ action, category, label, value }: GAEvent) => {
+  if (!isAnalyticsEnabled()) return;
+  window.gtag('event', action, {
+    event_category: category,
+    event_label: label,
+    value,
+  });
+};
+
+// Convenience helper for click tracking used throughout the site.
+export const trackClick = (label: string, category = 'engagement') =>
+  event({ action: 'click', category, label });
+
+declare global {
+  interface Window {
+    gtag: (...args: any[]) => void;
+    dataLayer: any[];
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@mantine/notifications": "6.0.2",
         "@mantine/prism": "6.0.2",
         "@next/bundle-analyzer": "^13.1.6",
-        "@react-google-maps/api": "^2.18.1",
         "@tabler/icons": "^1.107.0",
         "@tabler/icons-react": "^2.4.0",
         "cookies-next": "^2.1.1",
@@ -28,9 +27,7 @@
         "hamburger-react": "^2.5.0",
         "next": "13.2.4",
         "react": "18.2.0",
-        "react-dom": "18.2.0",
-        "react-google-maps": "^9.4.5",
-        "recompose": "^0.30.0"
+        "react-dom": "18.2.0"
       },
       "devDependencies": {
         "@babel/core": "^7.17.8",
@@ -69,6 +66,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
       "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.0"
       },
@@ -91,6 +89,7 @@
       "version": "7.17.7",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.7.tgz",
       "integrity": "sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -99,6 +98,7 @@
       "version": "7.17.8",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.8.tgz",
       "integrity": "sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==",
+      "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.16.7",
@@ -128,6 +128,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.9.tgz",
       "integrity": "sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.9",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -166,6 +167,7 @@
       "version": "7.17.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.7.tgz",
       "integrity": "sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==",
+      "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.17.7",
         "@babel/helper-validator-option": "^7.16.7",
@@ -239,6 +241,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
       "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -259,6 +262,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
       "integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
+      "dev": true,
       "dependencies": {
         "@babel/template": "^7.18.6",
         "@babel/types": "^7.18.9"
@@ -271,6 +275,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
       "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.6"
       },
@@ -305,6 +310,7 @@
       "version": "7.17.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz",
       "integrity": "sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.16.7",
         "@babel/helper-module-imports": "^7.16.7",
@@ -373,6 +379,7 @@
       "version": "7.17.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
       "integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.17.0"
       },
@@ -396,6 +403,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
       "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.18.6"
       },
@@ -415,6 +423,7 @@
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
       "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -438,6 +447,7 @@
       "version": "7.17.8",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.8.tgz",
       "integrity": "sha512-QcL86FGxpfSJwGtAvv4iG93UL6bmqBdmoVY0CMCU2g+oD2ezQse3PT5Pa+jiD6LJndBQi0EDlpzOWNlLuhz5gw==",
+      "dev": true,
       "dependencies": {
         "@babel/template": "^7.16.7",
         "@babel/traverse": "^7.17.3",
@@ -464,6 +474,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.9.tgz",
       "integrity": "sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==",
+      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1883,6 +1894,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
       "integrity": "sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
         "@babel/parser": "^7.18.6",
@@ -1896,6 +1908,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.9.tgz",
       "integrity": "sha512-LcPAnujXGwBgv3/WHv01pHtb2tihcyW1XuL9wd7jqh1Z8AQkTd+QVjMrMijrln0T7ED3UXLIy36P9Ao7W75rYg==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
         "@babel/generator": "^7.18.9",
@@ -2154,23 +2167,6 @@
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "dev": true
-    },
-    "node_modules/@googlemaps/js-api-loader": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.15.1.tgz",
-      "integrity": "sha512-AsnEgNsB7S/VdrHGEQUaUM2e5tmjFGKBAfzR/AqO8O7TPq/jQGvoRw5liPBw4EMF38RDsHmKDV89q/X+qiUREQ==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3"
-      }
-    },
-    "node_modules/@googlemaps/markerclusterer": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@googlemaps/markerclusterer/-/markerclusterer-2.0.15.tgz",
-      "integrity": "sha512-/I6Esi5FtyeVHsezN9Kut8zRJoqe7KkTIJXGVqpKFf6BjC7qQ1xRajLMkOz0s8XKgLevbr+KdYjuvmj+LohOGg==",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "supercluster": "^7.1.3"
-      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.9.5",
@@ -2921,6 +2917,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
       "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -2934,6 +2931,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
       "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -2942,6 +2940,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
       "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -2949,12 +2948,14 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
-      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg=="
+      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
       "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -3704,33 +3705,6 @@
       "peerDependencies": {
         "react": "^16.8 || ^17.0 || ^18.0"
       }
-    },
-    "node_modules/@react-google-maps/api": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/@react-google-maps/api/-/api-2.18.1.tgz",
-      "integrity": "sha512-KVlUO/Shh+0g/3egWaKmY0sz6+0QOnYkBGvrBMJbz23519LauA+iJFc4NDCmWNHqD5Vhb/Bkg0kSJgq0Stz3Iw==",
-      "dependencies": {
-        "@googlemaps/js-api-loader": "1.15.1",
-        "@googlemaps/markerclusterer": "2.0.15",
-        "@react-google-maps/infobox": "2.16.0",
-        "@react-google-maps/marker-clusterer": "2.16.1",
-        "@types/google.maps": "3.50.5",
-        "invariant": "2.2.4"
-      },
-      "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18",
-        "react-dom": "^16.8 || ^17 || ^18"
-      }
-    },
-    "node_modules/@react-google-maps/infobox": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/@react-google-maps/infobox/-/infobox-2.16.0.tgz",
-      "integrity": "sha512-ZojiMS25388RcUHQPycUAerSqdHDom+3dHczVcXHdT/i8fka3O8InkHxXwMhvBoM143ips7mv2BPaYOAJ5f4Nw=="
-    },
-    "node_modules/@react-google-maps/marker-clusterer": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/@react-google-maps/marker-clusterer/-/marker-clusterer-2.16.1.tgz",
-      "integrity": "sha512-jOuyqzWLeXvQcoAu6TCVWHAuko+sDt0JjawNHBGqUNLywMtTCvYP0L0PiqJZOUCUeRYGdUy0AKxQ+30vAkvwag=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -5738,27 +5712,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/google-maps": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@types/google-maps/-/google-maps-3.2.6.tgz",
-      "integrity": "sha512-ySOadZErcnCnNG+Zkmv5n+QG9DyTt7Mkx5Yk1dTjjNPtD8ByFaf+klZ/CxzgYcweduWEijTP0ASkANl57D0PRQ==",
-      "peer": true,
-      "dependencies": {
-        "@types/google.maps": "*"
-      }
-    },
-    "node_modules/@types/google.maps": {
-      "version": "3.50.5",
-      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.50.5.tgz",
-      "integrity": "sha512-RuZf1MJtctGlpW+Gd4a/eGtAufUDjMf+eyN1l+B3fbe2YLScJbg8KEljJfb+6vnSPFAeM1/48geVIEg3vqOkxw=="
-    },
-    "node_modules/@types/googlemaps": {
-      "version": "3.43.3",
-      "resolved": "https://registry.npmjs.org/@types/googlemaps/-/googlemaps-3.43.3.tgz",
-      "integrity": "sha512-ZWNoz/O8MPEpiajvj7QiqCY8tTLFNqNZ/a+s+zTV58wFVNAvvqV4bdGfnsjTb5Cs4V6wEsLrX8XRhmnyYJ2Tdg==",
-      "deprecated": "Types for the Google Maps browser API have moved to @types/google.maps. Note: these types are not for the googlemaps npm package, which is a Node API.",
-      "peer": true
-    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -5841,15 +5794,6 @@
       "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
       "dev": true
     },
-    "node_modules/@types/markerclustererplus": {
-      "version": "2.1.33",
-      "resolved": "https://registry.npmjs.org/@types/markerclustererplus/-/markerclustererplus-2.1.33.tgz",
-      "integrity": "sha512-ZDxsLUp8BmK9MVZZeQVDDzVrEXgRL0021AQcfXqfreFhdfZ9+PS0P6o4nZBvoIVYTmGSBemdCdI6mL6hf9yWvg==",
-      "peer": true,
-      "dependencies": {
-        "@types/google-maps": "*"
-      }
-    },
     "node_modules/@types/mdast": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.10.tgz",
@@ -5919,7 +5863,8 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
+      "dev": true
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
@@ -5931,6 +5876,7 @@
       "version": "18.0.21",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.21.tgz",
       "integrity": "sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==",
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -5949,7 +5895,8 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "dev": true
     },
     "node_modules/@types/source-list-map": {
       "version": "0.1.2",
@@ -7107,11 +7054,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
-    },
     "node_modules/asn1.js": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
@@ -7688,27 +7630,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
-      "dependencies": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
-    "node_modules/babel-runtime/node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "hasInstallScript": true
-    },
-    "node_modules/babel-runtime/node_modules/regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-    },
     "node_modules/bail": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
@@ -8172,6 +8093,7 @@
       "version": "4.20.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
       "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8199,7 +8121,8 @@
     "node_modules/browserslist/node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
     },
     "node_modules/bs-logger": {
       "version": "0.2.6",
@@ -8437,11 +8360,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/can-use-dom": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/can-use-dom/-/can-use-dom-0.1.0.tgz",
-      "integrity": "sha512-ceOhN1DL7Y4O6M0j9ICgmTYziV89WMd96SvSl0REd8PMgrY0B/WBOPoed5S1KUmJqXgUXh8gzSe6E3ae27upsQ=="
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001415",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001415.tgz",
@@ -8496,11 +8414,6 @@
       "engines": {
         "node": ">=0.8.0"
       }
-    },
-    "node_modules/change-emitter": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-      "integrity": "sha512-YXzt1cQ4a2jqazhcuSWEOc1K2q8g9H6eWNsyZgi640LDzRWVQ2eDe+Y/kVdftH+vYdPF2rgDb3dLdpxE1jvAxw=="
     },
     "node_modules/char-regex": {
       "version": "1.0.2",
@@ -9897,6 +9810,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -10400,7 +10314,8 @@
     "node_modules/electron-to-chromium": {
       "version": "1.4.103",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.103.tgz",
-      "integrity": "sha512-c/uKWR1Z/W30Wy/sx3dkZoj4BijbXX85QKWu9jJfjho3LBAXNEGAEW3oWiGb+dotA6C6BzCTxL2/aLes7jlUeg=="
+      "integrity": "sha512-c/uKWR1Z/W30Wy/sx3dkZoj4BijbXX85QKWu9jJfjho3LBAXNEGAEW3oWiGb+dotA6C6BzCTxL2/aLes7jlUeg==",
+      "dev": true
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -10473,25 +10388,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/end-of-stream": {
@@ -10795,6 +10691,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -12019,26 +11916,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fbjs": {
-      "version": "0.8.18",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.18.tgz",
-      "integrity": "sha512-EQaWFK+fEPSoibjNy8IxUtaFOMXcWsY0JaVrQoZR9zC8N2Ygf9iDITPWjUTVIax95b6I742JFLqASHfsag/vKA==",
-      "dependencies": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.30"
-      }
-    },
-    "node_modules/fbjs/node_modules/core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js."
-    },
     "node_modules/fetch-retry": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-5.0.3.tgz",
@@ -12738,6 +12615,7 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -12896,6 +12774,7 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -12934,11 +12813,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/google-maps-infobox": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/google-maps-infobox/-/google-maps-infobox-2.0.0.tgz",
-      "integrity": "sha512-hTuWmWZZSOxf5D/z7l3/hTF1grgRvLG53BEKMdjiKOG+FcK/kH7vqseUeyIU9Zj2ZIqKTOaro0nknxpAuRq4Vw=="
     },
     "node_modules/graceful-fs": {
       "version": "4.2.9",
@@ -14398,32 +14272,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==",
-      "dependencies": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
-    },
-    "node_modules/isomorphic-fetch/node_modules/is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/isomorphic-fetch/node_modules/node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "dependencies": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
       }
     },
     "node_modules/isomorphic-unfetch": {
@@ -16362,6 +16210,7 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -16396,6 +16245,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "dev": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -16436,11 +16286,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/kdbush": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
-      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -16795,16 +16640,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/marker-clusterer-plus": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/marker-clusterer-plus/-/marker-clusterer-plus-2.1.4.tgz",
-      "integrity": "sha512-4WLZnYCkgsUfSC0pftldd0YrLNupSqVIEdxL979f3sXVMBHTUOF3gDa6cEuOk2z8UGyVGcANiNZgvVc333mrHA=="
-    },
-    "node_modules/markerwithlabel": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/markerwithlabel/-/markerwithlabel-2.0.2.tgz",
-      "integrity": "sha512-C/cbm1A0h/u54gwHk5ZJNdUU3V3+1BbCpRPMsMyFA7vF4yL+aB4rWpxACz29TpQ+cTg6/iQroExh0PMSRGtQFg=="
     },
     "node_modules/md5.js": {
       "version": "1.3.5",
@@ -17444,7 +17279,8 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/multipipe": {
       "version": "1.0.2",
@@ -17774,7 +17610,8 @@
     "node_modules/node-releases": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg=="
+      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
+      "dev": true
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -18928,14 +18765,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
-    "node_modules/promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "dependencies": {
-        "asap": "~2.0.3"
-      }
-    },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -19294,59 +19123,10 @@
         "react": "^18.2.0"
       }
     },
-    "node_modules/react-google-maps": {
-      "version": "9.4.5",
-      "resolved": "https://registry.npmjs.org/react-google-maps/-/react-google-maps-9.4.5.tgz",
-      "integrity": "sha512-8z5nX9DxIcBCXuEiurmRT1VXVwnzx0C6+3Es6lxB2/OyY2SLax2/LcDu6Aldxnl3HegefTL7NJzGeaKAJ61pOA==",
-      "dependencies": {
-        "babel-runtime": "^6.11.6",
-        "can-use-dom": "^0.1.0",
-        "google-maps-infobox": "^2.0.0",
-        "invariant": "^2.2.1",
-        "lodash": "^4.16.2",
-        "marker-clusterer-plus": "^2.1.4",
-        "markerwithlabel": "^2.0.1",
-        "prop-types": "^15.5.8",
-        "recompose": "^0.26.0",
-        "scriptjs": "^2.5.8",
-        "warning": "^3.0.0"
-      },
-      "peerDependencies": {
-        "@types/googlemaps": "^3.0.0",
-        "@types/markerclustererplus": "^2.1.29",
-        "@types/react": "^15.0.0 || ^16.0.0",
-        "react": "^15.0.0 || ^16.0.0",
-        "react-dom": "^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/react-google-maps/node_modules/hoist-non-react-statics": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-    },
-    "node_modules/react-google-maps/node_modules/recompose": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
-      "integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
-      "dependencies": {
-        "change-emitter": "^0.1.2",
-        "fbjs": "^0.8.1",
-        "hoist-non-react-statics": "^2.3.1",
-        "symbol-observable": "^1.0.4"
-      },
-      "peerDependencies": {
-        "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
-    "node_modules/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "node_modules/react-property": {
       "version": "2.0.0",
@@ -19589,27 +19369,6 @@
       "engines": {
         "node": ">=8.10.0"
       }
-    },
-    "node_modules/recompose": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
-      "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "change-emitter": "^0.1.2",
-        "fbjs": "^0.8.1",
-        "hoist-non-react-statics": "^2.3.1",
-        "react-lifecycles-compat": "^3.0.2",
-        "symbol-observable": "^1.0.4"
-      },
-      "peerDependencies": {
-        "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/recompose/node_modules/hoist-non-react-statics": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -19994,16 +19753,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/requireindex": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
@@ -20165,7 +19914,8 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "node_modules/saxes": {
       "version": "5.0.1",
@@ -20205,15 +19955,11 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/scriptjs": {
-      "version": "2.5.9",
-      "resolved": "https://registry.npmjs.org/scriptjs/-/scriptjs-2.5.9.tgz",
-      "integrity": "sha512-qGVDoreyYiP1pkQnbnFAUIS5AjenNwwQBdl7zeos9etl+hYKWahjRTfzAZZYBv5xNHx7vNKCmaLDQZ6Fr2AEXg=="
-    },
     "node_modules/semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -20360,7 +20106,8 @@
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU= sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU= sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -21364,14 +21111,6 @@
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
       "integrity": "sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag=="
     },
-    "node_modules/supercluster": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
-      "integrity": "sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==",
-      "dependencies": {
-        "kdbush": "^3.0.0"
-      }
-    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -21426,14 +21165,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/symbol-tree": {
@@ -22246,24 +21977,6 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/ua-parser-js": {
-      "version": "0.7.35",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
-      "integrity": "sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ],
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/uglify-js": {
       "version": "3.15.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.3.tgz",
@@ -22940,14 +22653,6 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha512-jMBt6pUrKn5I+OGgtQ4YZLdhIeJmObddh6CsibPxyQ5yPZm1XExSyzC1LCNX7BzhxWgiHmizBWJTHJIjMjTQYQ==",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/watchpack": {
@@ -23978,11 +23683,6 @@
         "iconv-lite": "0.4.24"
       }
     },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
-    },
     "node_modules/whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
@@ -24288,6 +23988,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
       "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+      "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.0"
       }
@@ -24303,12 +24004,14 @@
     "@babel/compat-data": {
       "version": "7.17.7",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.7.tgz",
-      "integrity": "sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ=="
+      "integrity": "sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==",
+      "dev": true
     },
     "@babel/core": {
       "version": "7.17.8",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.8.tgz",
       "integrity": "sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==",
+      "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.16.7",
@@ -24331,6 +24034,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.9.tgz",
       "integrity": "sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.18.9",
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -24360,6 +24064,7 @@
       "version": "7.17.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.7.tgz",
       "integrity": "sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==",
+      "dev": true,
       "requires": {
         "@babel/compat-data": "^7.17.7",
         "@babel/helper-validator-option": "^7.16.7",
@@ -24411,7 +24116,8 @@
     "@babel/helper-environment-visitor": {
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg=="
+      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+      "dev": true
     },
     "@babel/helper-explode-assignable-expression": {
       "version": "7.16.7",
@@ -24426,6 +24132,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
       "integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
+      "dev": true,
       "requires": {
         "@babel/template": "^7.18.6",
         "@babel/types": "^7.18.9"
@@ -24435,6 +24142,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
       "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.18.6"
       }
@@ -24460,6 +24168,7 @@
       "version": "7.17.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz",
       "integrity": "sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==",
+      "dev": true,
       "requires": {
         "@babel/helper-environment-visitor": "^7.16.7",
         "@babel/helper-module-imports": "^7.16.7",
@@ -24513,6 +24222,7 @@
       "version": "7.17.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
       "integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.17.0"
       }
@@ -24530,6 +24240,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
       "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.18.6"
       }
@@ -24542,7 +24253,8 @@
     "@babel/helper-validator-option": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
-      "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ=="
+      "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
+      "dev": true
     },
     "@babel/helper-wrap-function": {
       "version": "7.16.8",
@@ -24560,6 +24272,7 @@
       "version": "7.17.8",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.8.tgz",
       "integrity": "sha512-QcL86FGxpfSJwGtAvv4iG93UL6bmqBdmoVY0CMCU2g+oD2ezQse3PT5Pa+jiD6LJndBQi0EDlpzOWNlLuhz5gw==",
+      "dev": true,
       "requires": {
         "@babel/template": "^7.16.7",
         "@babel/traverse": "^7.17.3",
@@ -24579,7 +24292,8 @@
     "@babel/parser": {
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.9.tgz",
-      "integrity": "sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg=="
+      "integrity": "sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==",
+      "dev": true
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
       "version": "7.16.7",
@@ -25524,6 +25238,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
       "integrity": "sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
         "@babel/parser": "^7.18.6",
@@ -25534,6 +25249,7 @@
       "version": "7.18.9",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.9.tgz",
       "integrity": "sha512-LcPAnujXGwBgv3/WHv01pHtb2tihcyW1XuL9wd7jqh1Z8AQkTd+QVjMrMijrln0T7ED3UXLIy36P9Ao7W75rYg==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
         "@babel/generator": "^7.18.9",
@@ -25666,8 +25382,7 @@
     "@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
-      "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
-      "requires": {}
+      "integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A=="
     },
     "@emotion/utils": {
       "version": "1.2.0",
@@ -25743,23 +25458,6 @@
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "dev": true
-    },
-    "@googlemaps/js-api-loader": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.15.1.tgz",
-      "integrity": "sha512-AsnEgNsB7S/VdrHGEQUaUM2e5tmjFGKBAfzR/AqO8O7TPq/jQGvoRw5liPBw4EMF38RDsHmKDV89q/X+qiUREQ==",
-      "requires": {
-        "fast-deep-equal": "^3.1.3"
-      }
-    },
-    "@googlemaps/markerclusterer": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@googlemaps/markerclusterer/-/markerclusterer-2.0.15.tgz",
-      "integrity": "sha512-/I6Esi5FtyeVHsezN9Kut8zRJoqe7KkTIJXGVqpKFf6BjC7qQ1xRajLMkOz0s8XKgLevbr+KdYjuvmj+LohOGg==",
-      "requires": {
-        "fast-deep-equal": "^3.1.3",
-        "supercluster": "^7.1.3"
-      }
     },
     "@humanwhocodes/config-array": {
       "version": "0.9.5",
@@ -26331,6 +26029,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
       "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
       "requires": {
         "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -26340,22 +26039,26 @@
     "@jridgewell/resolve-uri": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
-      "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew=="
+      "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+      "dev": true
     },
     "@jridgewell/set-array": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
-      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg=="
+      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
+      "dev": true
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
       "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+      "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -26402,8 +26105,7 @@
     "@mantine/hooks": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-6.0.2.tgz",
-      "integrity": "sha512-wLSkp0NRe4XN7JujIUvkKghIBJC9YZ33CJlrFbcBFLD6LiSLX7lWyWOsiFzXrPND0Hpgn3AjckFQGblA8n34XA==",
-      "requires": {}
+      "integrity": "sha512-wLSkp0NRe4XN7JujIUvkKghIBJC9YZ33CJlrFbcBFLD6LiSLX7lWyWOsiFzXrPND0Hpgn3AjckFQGblA8n34XA=="
     },
     "@mantine/next": {
       "version": "6.0.2",
@@ -26453,8 +26155,7 @@
     "@mantine/utils": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@mantine/utils/-/utils-6.0.2.tgz",
-      "integrity": "sha512-fx+cmkb8PMpkr65nUs8YgaXFJbtNY+ybSXDfBxwFAWMTLAocbNo7vjkSvPWZVS1O2szPK/s4Rqdw0W76dyG4+w==",
-      "requires": {}
+      "integrity": "sha512-fx+cmkb8PMpkr65nUs8YgaXFJbtNY+ybSXDfBxwFAWMTLAocbNo7vjkSvPWZVS1O2szPK/s4Rqdw0W76dyG4+w=="
     },
     "@mdx-js/mdx": {
       "version": "1.6.22",
@@ -26835,29 +26536,6 @@
       "requires": {
         "@babel/runtime": "^7.13.10"
       }
-    },
-    "@react-google-maps/api": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/@react-google-maps/api/-/api-2.18.1.tgz",
-      "integrity": "sha512-KVlUO/Shh+0g/3egWaKmY0sz6+0QOnYkBGvrBMJbz23519LauA+iJFc4NDCmWNHqD5Vhb/Bkg0kSJgq0Stz3Iw==",
-      "requires": {
-        "@googlemaps/js-api-loader": "1.15.1",
-        "@googlemaps/markerclusterer": "2.0.15",
-        "@react-google-maps/infobox": "2.16.0",
-        "@react-google-maps/marker-clusterer": "2.16.1",
-        "@types/google.maps": "3.50.5",
-        "invariant": "2.2.4"
-      }
-    },
-    "@react-google-maps/infobox": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/@react-google-maps/infobox/-/infobox-2.16.0.tgz",
-      "integrity": "sha512-ZojiMS25388RcUHQPycUAerSqdHDom+3dHczVcXHdT/i8fka3O8InkHxXwMhvBoM143ips7mv2BPaYOAJ5f4Nw=="
-    },
-    "@react-google-maps/marker-clusterer": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/@react-google-maps/marker-clusterer/-/marker-clusterer-2.16.1.tgz",
-      "integrity": "sha512-jOuyqzWLeXvQcoAu6TCVWHAuko+sDt0JjawNHBGqUNLywMtTCvYP0L0PiqJZOUCUeRYGdUy0AKxQ+30vAkvwag=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
@@ -28111,8 +27789,7 @@
     "@tabler/icons": {
       "version": "1.107.0",
       "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-1.107.0.tgz",
-      "integrity": "sha512-HlNN5uXPr9NUD2IqTNv5HfL2P3P8RT8VzYip3CBSiB4t9n7ZNFj/9gJRKgy9ONn9AN+hqACRaisu7M+koLAZzA==",
-      "requires": {}
+      "integrity": "sha512-HlNN5uXPr9NUD2IqTNv5HfL2P3P8RT8VzYip3CBSiB4t9n7ZNFj/9gJRKgy9ONn9AN+hqACRaisu7M+koLAZzA=="
     },
     "@tabler/icons-react": {
       "version": "2.4.0",
@@ -28280,8 +27957,7 @@
       "version": "14.0.4",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.0.4.tgz",
       "integrity": "sha512-VBZe5lcUsmrQyOwIFvqOxLBoaTw1/Qy4Ek+VgmFYs719bs2SxUp42vbsb7ATlQDkHdj4OIQlucfpwxe5WoG1jA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@tootallnate/once": {
       "version": "1.1.2",
@@ -28356,26 +28032,6 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
-    },
-    "@types/google-maps": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@types/google-maps/-/google-maps-3.2.6.tgz",
-      "integrity": "sha512-ySOadZErcnCnNG+Zkmv5n+QG9DyTt7Mkx5Yk1dTjjNPtD8ByFaf+klZ/CxzgYcweduWEijTP0ASkANl57D0PRQ==",
-      "peer": true,
-      "requires": {
-        "@types/google.maps": "*"
-      }
-    },
-    "@types/google.maps": {
-      "version": "3.50.5",
-      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.50.5.tgz",
-      "integrity": "sha512-RuZf1MJtctGlpW+Gd4a/eGtAufUDjMf+eyN1l+B3fbe2YLScJbg8KEljJfb+6vnSPFAeM1/48geVIEg3vqOkxw=="
-    },
-    "@types/googlemaps": {
-      "version": "3.43.3",
-      "resolved": "https://registry.npmjs.org/@types/googlemaps/-/googlemaps-3.43.3.tgz",
-      "integrity": "sha512-ZWNoz/O8MPEpiajvj7QiqCY8tTLFNqNZ/a+s+zTV58wFVNAvvqV4bdGfnsjTb5Cs4V6wEsLrX8XRhmnyYJ2Tdg==",
-      "peer": true
     },
     "@types/graceful-fs": {
       "version": "4.1.5",
@@ -28459,15 +28115,6 @@
       "integrity": "sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==",
       "dev": true
     },
-    "@types/markerclustererplus": {
-      "version": "2.1.33",
-      "resolved": "https://registry.npmjs.org/@types/markerclustererplus/-/markerclustererplus-2.1.33.tgz",
-      "integrity": "sha512-ZDxsLUp8BmK9MVZZeQVDDzVrEXgRL0021AQcfXqfreFhdfZ9+PS0P6o4nZBvoIVYTmGSBemdCdI6mL6hf9yWvg==",
-      "peer": true,
-      "requires": {
-        "@types/google-maps": "*"
-      }
-    },
     "@types/mdast": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.10.tgz",
@@ -28537,7 +28184,8 @@
     "@types/prop-types": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
+      "dev": true
     },
     "@types/qs": {
       "version": "6.9.7",
@@ -28549,6 +28197,7 @@
       "version": "18.0.21",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.21.tgz",
       "integrity": "sha512-7QUCOxvFgnD5Jk8ZKlUAhVcRj7GuJRjnjjiY/IUBWKgOlnvDvTMLD4RTF7NPyVmbRhNrbomZiOepg7M/2Kj1mA==",
+      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -28567,7 +28216,8 @@
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "dev": true
     },
     "@types/source-list-map": {
       "version": "0.1.2",
@@ -29096,8 +28746,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -29171,15 +28820,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-align": {
       "version": "3.0.1",
@@ -29432,11 +29079,6 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
       "dev": true
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "asn1.js": {
       "version": "5.4.1",
@@ -29890,27 +29532,6 @@
         "babel-preset-current-node-syntax": "^1.0.0"
       }
     },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.12",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-        },
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-        }
-      }
-    },
     "bail": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
@@ -30283,6 +29904,7 @@
       "version": "4.20.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
       "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
+      "dev": true,
       "requires": {
         "caniuse-lite": "^1.0.30001317",
         "electron-to-chromium": "^1.4.84",
@@ -30294,7 +29916,8 @@
         "picocolors": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-          "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+          "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+          "dev": true
         }
       }
     },
@@ -30495,11 +30118,6 @@
         }
       }
     },
-    "can-use-dom": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/can-use-dom/-/can-use-dom-0.1.0.tgz",
-      "integrity": "sha512-ceOhN1DL7Y4O6M0j9ICgmTYziV89WMd96SvSl0REd8PMgrY0B/WBOPoed5S1KUmJqXgUXh8gzSe6E3ae27upsQ=="
-    },
     "caniuse-lite": {
       "version": "1.0.30001415",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001415.tgz",
@@ -30533,11 +30151,6 @@
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ= sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
         }
       }
-    },
-    "change-emitter": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-      "integrity": "sha512-YXzt1cQ4a2jqazhcuSWEOc1K2q8g9H6eWNsyZgi640LDzRWVQ2eDe+Y/kVdftH+vYdPF2rgDb3dLdpxE1jvAxw=="
     },
     "char-regex": {
       "version": "1.0.2",
@@ -31669,6 +31282,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -32084,7 +31698,8 @@
     "electron-to-chromium": {
       "version": "1.4.103",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.103.tgz",
-      "integrity": "sha512-c/uKWR1Z/W30Wy/sx3dkZoj4BijbXX85QKWu9jJfjho3LBAXNEGAEW3oWiGb+dotA6C6BzCTxL2/aLes7jlUeg=="
+      "integrity": "sha512-c/uKWR1Z/W30Wy/sx3dkZoj4BijbXX85QKWu9jJfjho3LBAXNEGAEW3oWiGb+dotA6C6BzCTxL2/aLes7jlUeg==",
+      "dev": true
     },
     "elliptic": {
       "version": "6.5.4",
@@ -32145,24 +31760,6 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k= sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "dev": true
-    },
-    "encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "requires": {
-        "iconv-lite": "^0.6.2"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        }
-      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -32413,7 +32010,8 @@
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
@@ -32611,8 +32209,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-mantine/-/eslint-config-mantine-2.0.0.tgz",
       "integrity": "sha512-uDADuiJLKmhH6tjaEOfhA9o7GRuTnL3DBiox6muOV7hmnV8ESJotfzovUsiknwBSTMqzLTIvo52Cvs213DFiwg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -32841,8 +32438,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-storybook": {
       "version": "0.5.7",
@@ -33346,27 +32942,6 @@
       "dev": true,
       "requires": {
         "bser": "2.1.1"
-      }
-    },
-    "fbjs": {
-      "version": "0.8.18",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.18.tgz",
-      "integrity": "sha512-EQaWFK+fEPSoibjNy8IxUtaFOMXcWsY0JaVrQoZR9zC8N2Ygf9iDITPWjUTVIax95b6I742JFLqASHfsag/vKA==",
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.30"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA=="
-        }
       }
     },
     "fetch-retry": {
@@ -33926,7 +33501,8 @@
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -34036,7 +33612,8 @@
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
     },
     "globalthis": {
       "version": "1.0.2",
@@ -34061,11 +33638,6 @@
         "slash": "^3.0.0"
       }
     },
-    "google-maps-infobox": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/google-maps-infobox/-/google-maps-infobox-2.0.0.tgz",
-      "integrity": "sha512-hTuWmWZZSOxf5D/z7l3/hTF1grgRvLG53BEKMdjiKOG+FcK/kH7vqseUeyIU9Zj2ZIqKTOaro0nknxpAuRq4Vw=="
-    },
     "graceful-fs": {
       "version": "4.2.9",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
@@ -34083,8 +33655,7 @@
     "hamburger-react": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hamburger-react/-/hamburger-react-2.5.0.tgz",
-      "integrity": "sha512-5GSXe+ucxTPJ0SkhIsPQ/PRDweZPIKya1lfahAuExx31SdheeUA4uOPfQIAirbKona8hvo79VDr5LJQzPXsdpw==",
-      "requires": {}
+      "integrity": "sha512-5GSXe+ucxTPJ0SkhIsPQ/PRDweZPIKya1lfahAuExx31SdheeUA4uOPfQIAirbKona8hvo79VDr5LJQzPXsdpw=="
     },
     "handlebars": {
       "version": "4.7.7",
@@ -35117,31 +34688,6 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8= sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true
     },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      },
-      "dependencies": {
-        "is-stream": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ=="
-        },
-        "node-fetch": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
-        }
-      }
-    },
     "isomorphic-unfetch": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
@@ -35930,8 +35476,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -36575,15 +36120,15 @@
           "version": "7.5.7",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
           "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
@@ -36611,7 +36156,8 @@
     "json5": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "dev": true
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -36638,11 +36184,6 @@
       "resolved": "https://registry.npmjs.org/junk/-/junk-3.1.0.tgz",
       "integrity": "sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==",
       "dev": true
-    },
-    "kdbush": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
-      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew=="
     },
     "kind-of": {
       "version": "6.0.3",
@@ -36926,16 +36467,6 @@
       "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
       "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
       "dev": true
-    },
-    "marker-clusterer-plus": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/marker-clusterer-plus/-/marker-clusterer-plus-2.1.4.tgz",
-      "integrity": "sha512-4WLZnYCkgsUfSC0pftldd0YrLNupSqVIEdxL979f3sXVMBHTUOF3gDa6cEuOk2z8UGyVGcANiNZgvVc333mrHA=="
-    },
-    "markerwithlabel": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/markerwithlabel/-/markerwithlabel-2.0.2.tgz",
-      "integrity": "sha512-C/cbm1A0h/u54gwHk5ZJNdUU3V3+1BbCpRPMsMyFA7vF4yL+aB4rWpxACz29TpQ+cTg6/iQroExh0PMSRGtQFg=="
     },
     "md5.js": {
       "version": "1.3.5",
@@ -37465,7 +36996,8 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "multipipe": {
       "version": "1.0.2",
@@ -37722,7 +37254,8 @@
     "node-releases": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg=="
+      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
+      "dev": true
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -38594,8 +38127,7 @@
     "prism-react-renderer": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-1.2.1.tgz",
-      "integrity": "sha512-w23ch4f75V1Tnz8DajsYKvY5lF7H1+WvzvLUcF0paFxkTHSp42RS0H5CttdN2Q8RR3DRGZ9v5xD/h3n8C8kGmg==",
-      "requires": {}
+      "integrity": "sha512-w23ch4f75V1Tnz8DajsYKvY5lF7H1+WvzvLUcF0paFxkTHSp42RS0H5CttdN2Q8RR3DRGZ9v5xD/h3n8C8kGmg=="
     },
     "process": {
       "version": "0.11.10",
@@ -38607,14 +38139,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "requires": {
-        "asap": "~2.0.3"
-      }
     },
     "promise-inflight": {
       "version": "1.0.1",
@@ -38885,8 +38409,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz",
       "integrity": "sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "react-dom": {
       "version": "18.2.0",
@@ -38897,51 +38420,10 @@
         "scheduler": "^0.23.0"
       }
     },
-    "react-google-maps": {
-      "version": "9.4.5",
-      "resolved": "https://registry.npmjs.org/react-google-maps/-/react-google-maps-9.4.5.tgz",
-      "integrity": "sha512-8z5nX9DxIcBCXuEiurmRT1VXVwnzx0C6+3Es6lxB2/OyY2SLax2/LcDu6Aldxnl3HegefTL7NJzGeaKAJ61pOA==",
-      "requires": {
-        "babel-runtime": "^6.11.6",
-        "can-use-dom": "^0.1.0",
-        "google-maps-infobox": "^2.0.0",
-        "invariant": "^2.2.1",
-        "lodash": "^4.16.2",
-        "marker-clusterer-plus": "^2.1.4",
-        "markerwithlabel": "^2.0.1",
-        "prop-types": "^15.5.8",
-        "recompose": "^0.26.0",
-        "scriptjs": "^2.5.8",
-        "warning": "^3.0.0"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-        },
-        "recompose": {
-          "version": "0.26.0",
-          "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
-          "integrity": "sha512-KwOu6ztO0mN5vy3+zDcc45lgnaUoaQse/a5yLVqtzTK13czSWnFGmXbQVmnoMgDkI5POd1EwIKSbjU1V7xdZog==",
-          "requires": {
-            "change-emitter": "^0.1.2",
-            "fbjs": "^0.8.1",
-            "hoist-non-react-statics": "^2.3.1",
-            "symbol-observable": "^1.0.4"
-          }
-        }
-      }
-    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-property": {
       "version": "2.0.0",
@@ -39107,26 +38589,6 @@
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
-      }
-    },
-    "recompose": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
-      "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "change-emitter": "^0.1.2",
-        "fbjs": "^0.8.1",
-        "hoist-non-react-statics": "^2.3.1",
-        "react-lifecycles-compat": "^3.0.2",
-        "symbol-observable": "^1.0.4"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-        }
       }
     },
     "redent": {
@@ -39428,13 +38890,6 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I= sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
     },
-    "require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
-      "peer": true
-    },
     "requireindex": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
@@ -39552,7 +39007,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "saxes": {
       "version": "5.0.1",
@@ -39582,15 +39038,11 @@
         "ajv-keywords": "^3.5.2"
       }
     },
-    "scriptjs": {
-      "version": "2.5.9",
-      "resolved": "https://registry.npmjs.org/scriptjs/-/scriptjs-2.5.9.tgz",
-      "integrity": "sha512-qGVDoreyYiP1pkQnbnFAUIS5AjenNwwQBdl7zeos9etl+hYKWahjRTfzAZZYBv5xNHx7vNKCmaLDQZ6Fr2AEXg=="
-    },
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
     },
     "send": {
       "version": "0.17.2",
@@ -39724,7 +39176,8 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU= sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU= sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true
     },
     "setprototypeof": {
       "version": "1.2.0",
@@ -40545,14 +39998,6 @@
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
       "integrity": "sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag=="
     },
-    "supercluster": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
-      "integrity": "sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==",
-      "requires": {
-        "kdbush": "^3.0.0"
-      }
-    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -40592,11 +40037,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
-    },
-    "symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "symbol-tree": {
       "version": "3.2.4",
@@ -41204,11 +40644,6 @@
       "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
-    "ua-parser-js": {
-      "version": "0.7.35",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
-      "integrity": "sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g=="
-    },
     "uglify-js": {
       "version": "3.15.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.3.tgz",
@@ -41532,14 +40967,12 @@
     "use-composed-ref": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.3.0.tgz",
-      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==",
-      "requires": {}
+      "integrity": "sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ=="
     },
     "use-isomorphic-layout-effect": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
-      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
-      "requires": {}
+      "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA=="
     },
     "use-latest": {
       "version": "1.2.1",
@@ -41708,14 +41141,6 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.12"
-      }
-    },
-    "warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha512-jMBt6pUrKn5I+OGgtQ4YZLdhIeJmObddh6CsibPxyQ5yPZm1XExSyzC1LCNX7BzhxWgiHmizBWJTHJIjMjTQYQ==",
-      "requires": {
-        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {
@@ -42432,8 +41857,7 @@
         "ws": {
           "version": "7.5.6",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
-          "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
-          "requires": {}
+          "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA=="
         }
       }
     },
@@ -42471,8 +41895,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/webpack-filter-warnings-plugin/-/webpack-filter-warnings-plugin-1.2.1.tgz",
       "integrity": "sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "webpack-hot-middleware": {
       "version": "2.25.1",
@@ -42542,11 +41965,6 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
-    },
-    "whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",
@@ -42694,8 +42112,7 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
       "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "x-default-browser": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@mantine/notifications": "6.0.2",
     "@mantine/prism": "6.0.2",
     "@next/bundle-analyzer": "^13.1.6",
-    "@react-google-maps/api": "^2.18.1",
     "@tabler/icons": "^1.107.0",
     "@tabler/icons-react": "^2.4.0",
     "cookies-next": "^2.1.1",
@@ -39,9 +38,7 @@
     "hamburger-react": "^2.5.0",
     "next": "13.2.4",
     "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "react-google-maps": "^9.4.5",
-    "recompose": "^0.30.0"
+    "react-dom": "18.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.17.8",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,24 +1,127 @@
+import { useEffect } from 'react';
 import NextApp, { AppProps, AppContext } from 'next/app';
+import { useRouter } from 'next/router';
 import { getCookie } from 'cookies-next';
 import Head from 'next/head';
-import { MantineProvider, ColorScheme, ColorSchemeProvider } from '@mantine/core';
+import Script from 'next/script';
+import { MantineProvider, ColorScheme } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
 import { Navigation } from '../components/Navigation/Navigation';
+import { GA_MEASUREMENT_ID, pageview } from '../lib/gtag';
+
+const SITE_URL = 'https://boket78.com';
+const SITE_TITLE = 'Boket78 — Restaurant in Bol, Brač';
+const SITE_DESCRIPTION =
+  'Boket78 is a restaurant in Bol on the island of Brač, serving traditional Dalmatian cuisine with a modern twist in a hidden secret garden. Fresh Adriatic seafood, local Brač lamb and curated Croatian wines.';
+
+// Restaurant structured data (schema.org) to help search engines and rich results.
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'Restaurant',
+  name: 'Boket78',
+  description: SITE_DESCRIPTION,
+  url: SITE_URL,
+  image: `${SITE_URL}/assets/landing.webp`,
+  servesCuisine: ['Dalmatian', 'Croatian', 'Mediterranean', 'Seafood'],
+  priceRange: '$$',
+  telephone: '+385995935023',
+  email: 'info@boket78.com',
+  address: {
+    '@type': 'PostalAddress',
+    streetAddress: 'Ul. Radića Frane 14',
+    addressLocality: 'Bol',
+    addressRegion: 'Brač',
+    postalCode: '21420',
+    addressCountry: 'HR',
+  },
+  sameAs: [
+    'https://www.facebook.com/boket78/',
+    'https://www.instagram.com/boket78.bol/',
+    'https://www.tripadvisor.com/Restaurant_Review-g303802-d24138556-Reviews-Boket78-Bol_Brac_Island_Split_Dalmatia_County_Dalmatia.html',
+  ],
+  openingHours: 'Mo-Su 12:00-24:00',
+};
 
 export default function App(props: AppProps & { colorScheme: ColorScheme }) {
   const { Component, pageProps } = props;
+  const router = useRouter();
+
+  // Track client-side route changes as page views in Google Analytics.
+  useEffect(() => {
+    if (!GA_MEASUREMENT_ID) return undefined;
+    const handleRouteChange = (url: string) => pageview(url);
+    router.events.on('routeChangeComplete', handleRouteChange);
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange);
+    };
+  }, [router.events]);
+
   return (
     <>
       <Head>
-        <title>Boket78</title>
+        <title>{SITE_TITLE}</title>
         <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width" />
+        <meta name="description" content={SITE_DESCRIPTION} />
+        <meta
+          name="keywords"
+          content="Boket78, restaurant Bol, Brač restaurant, Dalmatian cuisine, Croatian food, seafood Bol, restaurant Brač island, secret garden restaurant"
+        />
+        <meta name="robots" content="index, follow" />
+        <meta name="theme-color" content="#02323C" />
+        <link rel="canonical" href={SITE_URL} />
         <link rel="shortcut icon" href="/favicon.ico" />
+
+        {/* Open Graph */}
+        <meta property="og:type" content="restaurant.restaurant" />
+        <meta property="og:site_name" content="Boket78" />
+        <meta property="og:title" content={SITE_TITLE} />
+        <meta property="og:description" content={SITE_DESCRIPTION} />
+        <meta property="og:url" content={SITE_URL} />
+        <meta property="og:image" content={`${SITE_URL}/assets/landing.webp`} />
+        <meta property="og:locale" content="en_US" />
+
+        {/* Twitter */}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={SITE_TITLE} />
+        <meta name="twitter:description" content={SITE_DESCRIPTION} />
+        <meta name="twitter:image" content={`${SITE_URL}/assets/landing.webp`} />
+
         <link href="https://awards.infcdn.net/r_rcm.css" rel="stylesheet" />
         <link
           href="https://fonts.googleapis.com/css2?family=Quicksand&display=swap"
           rel="stylesheet"
         />
+
+        {/* eslint-disable-next-line react/no-danger */}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+        />
       </Head>
+
+      {/* Google Analytics 4 — only loaded when a measurement ID is configured. */}
+      {GA_MEASUREMENT_ID && (
+        <>
+          <Script
+            strategy="afterInteractive"
+            src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+          />
+          <Script
+            id="google-analytics"
+            strategy="afterInteractive"
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{
+              __html: `
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', '${GA_MEASUREMENT_ID}', { page_path: window.location.pathname });
+              `,
+            }}
+          />
+        </>
+      )}
+
       <MantineProvider
         withGlobalStyles
         withNormalizeCSS
@@ -30,6 +133,15 @@ export default function App(props: AppProps & { colorScheme: ColorScheme }) {
             pml: '70em',
             xxl: '98em',
           },
+          globalStyles: () => ({
+            html: {
+              scrollBehavior: 'smooth',
+              overflowX: 'hidden',
+            },
+            body: {
+              overflowX: 'hidden',
+            },
+          }),
           components: {
             Button: {
               styles: {
@@ -63,14 +175,6 @@ export default function App(props: AppProps & { colorScheme: ColorScheme }) {
                 },
               },
             },
-            Flex: {
-              styles: {
-                root: {
-                  backgroundColor: '#659499',
-                  width: '30px',
-                },
-              },
-            },
           },
         }}
       >
@@ -87,6 +191,6 @@ App.getInitialProps = async (appContext: AppContext) => {
   const appProps = await NextApp.getInitialProps(appContext);
   return {
     ...appProps,
-    colorScheme: getCookie('mantine-color-scheme', appContext.ctx) || 'dark',
+    colorScheme: getCookie('mantine-color-scheme', appContext.ctx) || 'light',
   };
 };

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -154,7 +154,6 @@ export default function App(props: AppProps & { colorScheme: ColorScheme }) {
               styles: {
                 root: {
                   color: 'white',
-                  textAlign: 'left',
                 },
               },
             },

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,8 +1,20 @@
-import Document from 'next/document';
+import Document, { Html, Head, Main, NextScript } from 'next/document';
 import { createGetInitialProps } from '@mantine/next';
 
 const getInitialProps = createGetInitialProps();
 
 export default class _Document extends Document {
   static getInitialProps = getInitialProps;
+
+  render() {
+    return (
+      <Html lang="en">
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,18 +8,24 @@ import { Legal } from '../components/Legal/Legal';
 
 export default function HomePage() {
   return (
-    <div
-      style={{
-        height: '100vh',
-      }}
-    >
-      <Welcome />
-      <About />
-      <Menu />
-      <CardsCarousel />
-      <DesignCardsCarousel />
-      <Contact />
+    <main>
+      <section id="landing">
+        <Welcome />
+      </section>
+      <section id="about">
+        <About />
+      </section>
+      <section id="menu">
+        <Menu />
+      </section>
+      <section id="gallery" style={{ overflowX: 'hidden' }}>
+        <CardsCarousel />
+        <DesignCardsCarousel />
+      </section>
+      <section id="contact">
+        <Contact />
+      </section>
       <Legal />
-    </div>
+    </main>
   );
 }

--- a/pages/info.tsx
+++ b/pages/info.tsx
@@ -1,13 +1,16 @@
+import Head from 'next/head';
 import { Info } from '../components/Info/Info';
 
-export default function HomePage() {
+export default function InfoPage() {
   return (
-    <div
-      style={{
-        height: '100vh',
-      }}
-    >
-        <Info/>
-    </div>
+    <>
+      <Head>
+        <title>Company Information — Boket78</title>
+        <meta name="description" content="Legal and company information for Boket78 restaurant (MORE BEER d.o.o.) in Bol, Brač." />
+        <meta name="robots" content="noindex, follow" />
+        <link rel="canonical" href="https://boket78.com/info" />
+      </Head>
+      <Info />
+    </>
   );
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://boket78.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://boket78.com/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://boket78.com/info</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary

Refactors the Boket78 site to fix layout & scrolling problems, optimise it for SEO, and add Google Analytics click tracking. Every change was verified against the production build with a headless browser at desktop, tablet and mobile widths.

## 🧭 Layout & scrolling
- **Fixed the navigation** — there was no way to open the menu (the toggle was never wired up), so it was completely unreachable. Added a working hamburger toggle with a reliable full-screen overlay, section anchor links and smooth scrolling. (Mantine's emotion styles were never emitted for this client-only-mounted component, so the overlay uses plain inline styles.)
- **Fixed the hero** — the tagline was pushed off-screen by nested `100vh` flexes; logo + tagline are now centered in a single viewport, and the title is centered with a responsive font size so it no longer overflows on phones.
- Switched fixed `100vh` → `min-height` so long sections (menu, contact, about-on-mobile) no longer clip their content.
- Removed a global theme override that forced **every** `Flex` to `width: 30px`, and one that forced `text-align: left` on all text (which broke centered titles).
- Eliminated horizontal scrollbars (`100vw` → `100%`, clipped carousel overflow, `overflow-x: hidden`). Verified 0px overflow on desktop/tablet/mobile.

## 🔎 SEO
- Added `lang="en"`, meta description/keywords/robots, canonical, Open Graph + Twitter cards, and `theme-color`.
- Added **Restaurant schema.org JSON-LD** structured data (address, hours, cuisine, socials).
- Semantic `h1`/`h2` headings and meaningful, descriptive image `alt` text (previously all *"Best forests to visit in North America"*).
- Added `robots.txt` and `sitemap.xml`; per-page metadata for `/info`.

## 📊 Analytics
- Added GA4 via `next/script`, gated behind `NEXT_PUBLIC_GA_MEASUREMENT_ID` (no-op until the ID is set — documented in `.env.example`).
- Tracks client-side route changes as page views.
- Tracks click events on nav links, menu buttons and contact/social links (`lib/gtag.ts` helper).

## Misc fixes
- Added `rel="noopener noreferrer"`, keys and `aria-label`s on external links.
- Fixed invalid React attributes in the Restaurant Guru widget.
- Corrected the "12AM–12PM" opening hours and a typo; styled the previously-unstyled info page.

## ⚙️ Follow-up for the maintainer
- Set `NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX` in the deployment environment to activate analytics.
- The site URL in the SEO tags is hardcoded to `https://boket78.com` — update if the production domain differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tuv84TJouYUFuL7JqTYzjb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tuv84TJouYUFuL7JqTYzjb)_