### PR TITLE
Make pages static so Cloudflare Pages (next-on-pages) build succeeds

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,10 +1,9 @@
 import { useEffect } from 'react';
-import NextApp, { AppProps, AppContext } from 'next/app';
+import { AppProps } from 'next/app';
 import { useRouter } from 'next/router';
-import { getCookie } from 'cookies-next';
 import Head from 'next/head';
 import Script from 'next/script';
-import { MantineProvider, ColorScheme } from '@mantine/core';
+import { MantineProvider } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
 import { Navigation } from '../components/Navigation/Navigation';
 import { GA_MEASUREMENT_ID, pageview } from '../lib/gtag';
@@ -42,7 +41,7 @@ const structuredData = {
   openingHours: 'Mo-Su 12:00-24:00',
 };
 
-export default function App(props: AppProps & { colorScheme: ColorScheme }) {
+export default function App(props: AppProps) {
   const { Component, pageProps } = props;
   const router = useRouter();
 
@@ -185,11 +184,3 @@ export default function App(props: AppProps & { colorScheme: ColorScheme }) {
     </>
   );
 }
-
-App.getInitialProps = async (appContext: AppContext) => {
-  const appProps = await NextApp.getInitialProps(appContext);
-  return {
-    ...appProps,
-    colorScheme: getCookie('mantine-color-scheme', appContext.ctx) || 'light',
-  };
-};


### PR DESCRIPTION
## Summary

Follow-up to #2. The Cloudflare Pages build (`npx @cloudflare/next-on-pages@1`) fails with:

```
The following routes were not configured to run with the Edge Runtime:
  - /_error
  - /index
  - /info
```

`@cloudflare/next-on-pages` requires every **server-rendered** route to opt into the Edge runtime. Our routes were only server-rendered because `_app.tsx` had a `getInitialProps` that read a `mantine-color-scheme` cookie — but that value was never used (the theme is hardcoded to `light`). That one function opted the whole app out of static optimization.

## Change
Removed the dead `getInitialProps` (and its now-unused `cookies-next` / `AppContext` / `ColorScheme` imports) from `pages/_app.tsx`. Nothing else depended on it.

## Result
- `next build` now marks every route as static (`○`) instead of server (`λ`).
- `npx @cloudflare/next-on-pages@1` completes locally with **"No functions detected"** — a pure static build, no edge-runtime requirement.
- Verified the static HTML still carries the `<title>`, `h1`, `lang="en"`, Restaurant JSON-LD and Mantine's extracted emotion CSS, so SEO and styling are unaffected.

Client-side behaviour (nav, carousels, Google Analytics page-views/click events) is unchanged — it was already client-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tuv84TJouYUFuL7JqTYzjb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tuv84TJouYUFuL7JqTYzjb)_